### PR TITLE
Add UnoRouter to Character & Roleplay Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Platforms focused on creating, sharing, and chatting with diverse AI characters.
 | [HammerAI](https://www.hammerai.com) | Unlimited free messages, PNG card import/export, local LLM support (Ollama), proxy mode for any API, lorebooks, image gen | Free / Paid | Web, Desktop |
 | [RealmsAI](http://realmsai.net) | Multi-character chats (50 chars), multiplayer, custom RAG memory, visual novel elements, director/god mode | Free (70 msg/day) / Premium | Android, Web |
 | [CharacterSphere.ai](https://charactersphere.ai/) | Community characters, scenarios, persistent character memory, multi-language, NSFW-friendly, character gallery, no message caps | Free (image gen paid) | Web, Discord, Telegram |
-| [UnoRouter](https://unorouter.ai) | RP chat with characters/personas/lorebooks/presets and SillyTavern card v2/v3 import, branch editing, image/video gen, also a built-in OpenAI-compatible API (212+ models, automatic failover) usable from SillyTavern/Janitor.AI/RisuAI/Chub | Free models / pay-as-you-go credits | Web |
+| [UnoRouter](https://unorouter.com) | RP chat with characters/personas/lorebooks/presets and SillyTavern card v2/v3 import, branch editing, image/video gen, also a built-in OpenAI-compatible API (212+ models, automatic failover) usable from SillyTavern/Janitor.AI/RisuAI/Chub | Free models / pay-as-you-go credits | Web |
 
 ## Anime-Style Companion Apps
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Platforms focused on creating, sharing, and chatting with diverse AI characters.
 | [HammerAI](https://www.hammerai.com) | Unlimited free messages, PNG card import/export, local LLM support (Ollama), proxy mode for any API, lorebooks, image gen | Free / Paid | Web, Desktop |
 | [RealmsAI](http://realmsai.net) | Multi-character chats (50 chars), multiplayer, custom RAG memory, visual novel elements, director/god mode | Free (70 msg/day) / Premium | Android, Web |
 | [CharacterSphere.ai](https://charactersphere.ai/) | Community characters, scenarios, persistent character memory, multi-language, NSFW-friendly, character gallery, no message caps | Free (image gen paid) | Web, Discord, Telegram |
+| [UnoRouter](https://unorouter.ai) | RP chat with characters/personas/lorebooks/presets and SillyTavern card v2/v3 import, branch editing, image/video gen, also a built-in OpenAI-compatible API (212+ models, automatic failover) usable from SillyTavern/Janitor.AI/RisuAI/Chub | Free models / pay-as-you-go credits | Web |
 
 ## Anime-Style Companion Apps
 


### PR DESCRIPTION
Adds UnoRouter to the Character & Roleplay Platforms table.

UnoRouter is a roleplay-focused chat platform (characters, personas, lorebooks, presets, SillyTavern card v2/v3 import, branch editing, image/video generation) that runs on its own OpenAI-compatible API across 212+ models with automatic failover. The same key also works in SillyTavern, Janitor.AI, RisuAI, and Chub.

- Site: https://unorouter.ai
- Entry follows the table format (Platform | Key Features | Pricing | Platforms).