### PR TITLE
Add DoaCam to AI Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Apps designed around long-running emotional/social interaction with a persistent
 | [Talkie](https://www.talkie-ai.com) | Mobile-first roleplay, anime-style characters, social features | Freemium | iOS, Android |
 | [BodyBuddy](https://bodybuddy.app) | Daily accountability companion for health in iMessage, persistent memory, gentle human-like personality, tracks and coaches to better health (exercise, sleep, meals, calories) | $29.99/mo (7-day trial) | iOS, iMessage |
 | [dmwithme](https://dmwithme.com) | Livestream-format SFW AI companion (live cam model, not static chat), AI characters with mood and emotion changes, unlimited messages, virtual gift coins | Freemium (coins for gifts, no monthly sub) | Web |
+| [DoaCam](https://doacam.com) | 16 built-in personalities, real-time voice conversation, persistent cross-session memory, activity modes (language lessons, tarot, text-adventure roleplay, riddles), live video call | Free | Web |
 | [Izzy & friends](https://apps.apple.com/us/app/izzy-friends/id6753328759) | Emotional journaling companion, multiple AI friends, voice notes, media recommendations, local event discovery, real-world nudges | $0.99 one-time | iOS |
 
 ## Character & Roleplay Platforms


### PR DESCRIPTION
Adds **DoaCam**, a free browser-based AI companion, to the **AI Companion Apps** section (placed alphabetically after dmwithme).

- **Active & accessible:** https://doacam.com
- **What it is:** free AI companion with 16 built-in personalities — real-time voice conversation, persistent cross-session memory, activity modes (language lessons, tarot, text-adventure roleplay, riddles), and live video call.
- **Unique:** live video call with on-camera vision plus switchable activity modes set it apart from the other listed apps.
- **Pricing:** Free. **Platform:** Web.

Follows the entry format and alphabetical ordering per CONTRIBUTING.md.