### PR TITLE
Add Foreverse (Android novel reader + roleplay app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Platforms focused on creating, sharing, and chatting with diverse AI characters.
 | [SpicyChat](https://spicychat.ai) | NSFW focus, character creation tools, persona marketplace | Freemium | Web |
 | [CrushOn.AI](https://crushon.ai) | Unfiltered conversations, character creation, multiple personas | $5.99-$49.99/mo | Web |
 | [EroPlay](https://eroplay.com) | Erotic RP focus, granular tag-based scenario/personality customization, free tier (inconsistent), premium tier (better long multi-turn) | Freemium | Web |
+| [Foreverse](https://foreverse.app) | AI novel reader with plot branching, spoiler-free chat with characters from your own books, SillyTavern card import (PNG/JSON/charx), lorebooks, group chat, companion mode with long-term memory | Free + optional credits (BYOK, 60+ providers) | Android |
 | [SillyTavern](https://sillytavern.app) | Self-hosted frontend, works with any LLM API, highly customizable | Free (self-hosted) | Web (local) |
 | [Chub.ai](https://chub.ai) | Character card repository, works with SillyTavern/other frontends | Free / Premium | Web |
 | [Poe](https://poe.com) | Multi-model access, custom bot creation, character marketplace | Free / $20/mo | iOS, Android, Web |


### PR DESCRIPTION
Adds **Foreverse** to Character & Roleplay Platforms (placed after EroPlay for rough alphabetical order).

Checklist against the inclusion requirements:
- **Active & accessible**: live on Google Play (https://play.google.com/store/apps/details?id=app.foreverse.android) and https://foreverse.app
- **Primarily an AI companion/character app**: SillyTavern-compatible character chat (PNG/JSON/charx cards, lorebooks, presets, regex, group chat) plus a companion mode with long-term memory; its twist is you can also chat with characters from novels you import
- **Available 1+ month**: launched earlier in 2026
- **Not a clone/spam**: original Android app, free with BYOK (users bring their own API key for 60+ providers; keys and chats stay on device)

Disclosure: I'm the developer.