### PR TITLE
Add Scowld to open-source companions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ For those who want to run their own AI companion locally.
 
 | Project | Description | Stars |
 |---------|-------------|-------|
+| [Scowld](https://github.com/apoorvdarshan/scowld) | Open-source iOS companion with an animated VRM character, voice and text chat, BYOK AI/STT/TTS providers, and optional camera context | ![Stars](https://img.shields.io/github/stars/apoorvdarshan/scowld?style=flat-square) |
 | [SillyTavern](https://github.com/SillyTavern/SillyTavern) | Feature-rich chat frontend for LLMs with character cards, group chats, extensions | ![Stars](https://img.shields.io/github/stars/SillyTavern/SillyTavern?style=flat-square) |
 | [TavernAI](https://github.com/TavernAI/TavernAI) | Original tavern-style chat frontend (predecessor to SillyTavern) | ![Stars](https://img.shields.io/github/stars/TavernAI/TavernAI?style=flat-square) |
 | [Oobabooga Text Generation WebUI](https://github.com/oobabooga/text-generation-webui) | Gradio interface for running LLMs locally, supports character chat | ![Stars](https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=flat-square) |


### PR DESCRIPTION
## What changed

Adds Scowld to the Open Source & Self-Hosted section.

Scowld is an MIT-licensed iOS AI companion featuring an animated VRM character, voice and text chat, user-configured AI/STT/TTS providers, and optional camera context.

## Why it fits

- The project is active and publicly accessible.
- It is specifically designed as an ongoing AI companion rather than a general productivity assistant.
- It has English-language support and has been publicly available for more than one month.
- It offers a distinct open-source, mobile-first companion experience.

## Validation

- Confirmed there was no existing Scowld entry or pull request.
- Followed the repository's three-column open-source project format.
- Verified the repository is public, active, and MIT licensed.
- Ran `git diff --check` successfully.

Sources: [GitHub](https://github.com/apoorvdarshan/scowld), [website](https://scowld.xyz), [App Store](https://apps.apple.com/app/id6760672848)
