### PR TITLE
Add Local Waifu to Anime-Style Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Apps with anime-style characters, visual novel elements, or anime-specific art/r
 | App | Key Features | Pricing | Platforms |
 |-----|-------------|---------|-----------|
 | [Get-Waifu](https://get-waifu.com) | Anime characters, community voting for new characters, archetype consistency, memory across RP | Freemium | Android, Web |
+| [Local Waifu](https://localwaifu.com) | Runs fully offline on your own machine (bundled local LLM, on-device image generation for selfies, voice), persistent long-term memory, vision, 8-axis personality builder, multiple characters, 7 languages, no account | $20 one-time (7-day free trial) | macOS, Windows |
 | [Moescape](https://moescape.ai) | Anime-style characters, visual novel format, image generation | Freemium | Web |
 
 ## AI Boyfriend/Girlfriend Apps


### PR DESCRIPTION
Adds [Local Waifu](https://localwaifu.com) to **Anime-Style Companion Apps**, in alphabetical order between Get-Waifu and Moescape.

### What it is

A desktop AI companion for macOS and Windows that runs entirely on the user's own machine — bundled local LLM, on-device image generation for selfies, local speech. No account to create, no telemetry, and it keeps working with outbound connections blocked. Anime-style character art by default, though the character (waifu, husbando, or non-binary) is built by the user across an 8-axis personality setup.

Distinct from everything currently on the list in two ways: it is local-first rather than a hosted service, and it is a one-time purchase rather than a subscription.

Other relevant features: persistent long-term memory across sessions and model swaps, image understanding, multiple characters with separate conversations, and 7 interface/reply languages.

### Against the inclusion requirements

- **Active** — v1.6.3 shipped 14 Aug 2026, signed macOS and Windows installers on the [releases page](https://github.com/lumizone/local-waifu/releases/latest).
- **Relevant** — companion/relationship app, not a general assistant.
- **Established** — public since v1.3, releases running continuously since June 2026.
- **Unique** — the only fully offline, no-subscription entry in this section.
- **Accurate** — $20 one-time (regular $25), 7-day free trial, 30-day refund; macOS 13+ Apple Silicon and Windows 10/11 x64.

Kept the description neutral and feature-only per the code of conduct. Disclosure: I'm the author.